### PR TITLE
feat(core): provide an abstraction to manage `CredentialProvider`

### DIFF
--- a/core/credentials/credentials_test.go
+++ b/core/credentials/credentials_test.go
@@ -13,7 +13,7 @@ func TestNew_InvalidToken(t *testing.T) {
 	_, err := New(token)
 
 	// assert
-	assert.Error(t, err, "unable to recognize the API key")
+	assert.EqualError(t, err, "unable to recognize the API key")
 }
 
 func TestNew_TokenNotDefined(t *testing.T) {
@@ -24,7 +24,7 @@ func TestNew_TokenNotDefined(t *testing.T) {
 	_, err := New(token)
 
 	// assert
-	assert.Error(t, err, "provide an API key")
+	assert.EqualError(t, err, "provide an API key")
 }
 
 func TestCredentials_Token(t *testing.T) {

--- a/core/credentials/provider.go
+++ b/core/credentials/provider.go
@@ -1,0 +1,5 @@
+package credentials
+
+type Provider interface {
+	Get() *Credentials
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.8.2
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
closes #10