### PR TITLE
build: retract v1.0.0 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Due to the workflow misconfiguration, the initial development release has been tagged by v1.0.0 instead of the expected v0.1.0
+// For details please refer to the GitHub issue at https://github.com/golang/go/issues/58852
+retract v1.0.0


### PR DESCRIPTION
Due to the misconfiguration, the initial development release has been tagged by v1.0.0 instead of the expected v0.1.0.

For details please refer to the GitHub issue at golang/go#58852